### PR TITLE
Permit string-only initial stack.

### DIFF
--- a/cmd/starfish/stack.go
+++ b/cmd/starfish/stack.go
@@ -47,7 +47,7 @@ func (s *stack) Set(str string) error {
 	if f, err := strconv.ParseFloat(string(runes), 64); err == nil {
 		s.s = append(s.s, f)
 		runes = make([]rune, 0, 32)
-	} else {
+	} else if len(runes) > 0 {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Prior to this commit, `strconv.ParseFloat()` was being passed an empty string in the event that the `-i` flag was used to set the initial stack to the contents of one or more strings and nothing else.